### PR TITLE
updating the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ A [Select2](https://select2.github.io/) v4 [Theme](https://select2.github.io/exa
 ![select2-bootstrap-theme version](https://img.shields.io/badge/select2--bootstrap--theme-v0.1.0--beta.10-brightgreen.svg)
 [![License](http://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
-Demonstrations available at
-[select2.github.io/select2-bootstrap-theme](http://select2.github.io/select2-bootstrap-theme/)
+Demonstrations [available](https://angel-vladov.github.io/select2-bootstrap-theme/).
 
 #### Compatibility
 


### PR DESCRIPTION
the page at the original link still lists Bootstrap 3. I've used the correct URL now.